### PR TITLE
Add note about subclassing

### DIFF
--- a/03-model-object.Rmd
+++ b/03-model-object.Rmd
@@ -1,5 +1,9 @@
 # The Model Object
 
+* If you create a custom model object, it should have a constructor, helper and validator [as outlined in Advanced R](https://adv-r.hadley.nz/s3.html#outline-9).
+
+* *Never* set the class of your model object using `class()`. Either use the constructor or the validator. Classes that do not have constructors and validators are not sufficiently robust to build off of.
+
 * Saving the call is discouraged. If it must be saved, it should be checked for size. In cases where the function is invoked by `do.call("foo", bar)`, the data set may be embedded in the argument list `bar`. 
 
 * Unless explicitly required by the model, the training set should not be embedded in the model object (exceptions being models such as _k_-nearest neighbors). 


### PR DESCRIPTION
An attempt to avoid the special hells accompanying subclassing `lm`, `anova`, or similar. Unfortunately, many of the canonical "copy this structure" functions in `MASS` do this and then break down the line.

Actually, I think is a really good rule of thumb that we should make sure to implement in `parsnip`: only create model objects from constructors/validators. We should probably also provide constructors and validators for `parsnip` objects in if we want them to be extensible. cc @DavisVaughan 