### PR TITLE
Fix small typos

### DIFF
--- a/02-function-interfaces.Rmd
+++ b/02-function-interfaces.Rmd
@@ -50,7 +50,7 @@ the computational code. [{note}](#decouple)
 
 * Computational code should (almost) always use `X[ , ,drop = FALSE]` when subsetting matrices (and non-tibble data frames) to make sure that the 2D structure is maintained. 
 
-* Use `try` or similar methods to avoid an uncontrolled errors in order to return intelligible errors. 
+* Use `try` or similar methods to avoid uncontrolled errors in order to return intelligible errors.
 
 <div id="calls-back"></div>
 

--- a/04-print-and-summary-methods.Rmd
+++ b/04-print-and-summary-methods.Rmd
@@ -8,4 +8,4 @@
     
     * Printing the call is discouraged.  
 
-* `summary` methods are helpful but not required. These should create more verbose descriptions of the object. the `print` method for the `summary` object should follow the bullet-pointed remarks above for printing. 
+* `summary` methods are helpful but not required. These should create more verbose descriptions of the object. The `print` method for the `summary` object should follow the bullet-pointed remarks above for printing.

--- a/07-parallelism.Rmd
+++ b/07-parallelism.Rmd
@@ -14,7 +14,7 @@
 
  * Computations should be easily reproducible, even when run in parallel. Parallelism should not be an excuse for irreproducibility.  [{note}](#par-seed)
  
- * Computational code in other languages (e.g. Cpp, etc.) should pull from R's random number streams so that settin the seed prior to invoking these routines ensures reproducibility. 
+ * Computational code in other languages (e.g. Cpp, etc.) should pull from R's random number streams so that setting the seed prior to invoking these routines ensures reproducibility.
 
 
 

--- a/08-notes.Rmd
+++ b/08-notes.Rmd
@@ -123,7 +123,7 @@ Historically, the call object that results from a model fit was considered a goo
 
 This can be problematic because the call object is relative to the environment and the call itself is agnostic to its original environment. If the call is changed and re-evaluated, the current environment may be inappropriate. This could result in errors due to the required objects not being exposed in the current environment.  
 
-Note that the internals of common modeling functions, such as `lm`, do exactly this. However, these manipulations occur _within_ the function call to that the environment is the same.  
+Note that the internals of common modeling functions, such as `lm`, do exactly this. However, these manipulations occur _within_ the function call so that the environment is the same.
 
 [`r emojifont::emoji('leftwards_arrow_with_hook')`](#calls-back)
 

--- a/index.Rmd
+++ b/index.Rmd
@@ -22,7 +22,7 @@ The S language has had unofficial conventions for modeling function, such as:
 
  * existing OOP classes like `predict`, `update`, etc. 
 
-Despite a [note](https://developer.r-project.org/model-fitting-functions.html) written by an R core member in 2003, these conventions have never been formally required for packages and this has led to a a significant amount of between- and within-package heterogeneity. For example, the table below shows myriad methods for obtaining class probability estimates for a set of modeling functions:
+Despite a [note](https://developer.r-project.org/model-fitting-functions.html) written by an R core member in 2003, these conventions have never been formally required for packages and this has led to a significant amount of between- and within-package heterogeneity. For example, the table below shows myriad methods for obtaining class probability estimates for a set of modeling functions:
 
 |Function      |Package      |Code                                       |
 |:-------------|:------------|:------------------------------------------|


### PR DESCRIPTION
This PR contains fixes for small typos. Please check that the changes made to `08-notes.Rmd` reflect the intended message.